### PR TITLE
set unicorn preload

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,5 @@
+`ssh-add`
+
 lock "~> 3.12.0"
 
 set :application, "groupme-for-techbang"

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -5,3 +5,24 @@ pid '/home/app/groupme-for-techbang/shared/tmp/pids/unicorn.pid'
 
 stderr_path 'log/unicorn.error.log'
 stdout_path 'log/unicorn.log'
+
+preload_app true
+
+before_fork do |server, worker|
+  defined?(ActiveRecord::Base) &&
+    ActiveRecord::Base.connection.disconnect!
+
+    old_pid = "#{server.config[:pid]}.oldbin"
+  if old_pid != server.pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+    end
+  end
+end
+
+after_fork do |server, worker|
+  defind?(ActiveRecord::Base) &&
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
- 啓用 config/unicorn.rb 裡的 preload_app 設定，同時於 before_fork 與 after_fork block 內中斷、重連 db（參考： http://unicorn.bogomips.org/examples/unicorn.conf.rb ）；
- deploy 時重啓 unicorn 的方式改成 unicorn:restart 。